### PR TITLE
Automate code formatting using Spotless and Palantir

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>3.1.7</version>
-        <relativePath/> <!-- lookup parent from repository -->
+        <relativePath/>
+        <!-- lookup parent from repository -->
     </parent>
 
     <groupId>org.github.ehayik.kata</groupId>
@@ -18,7 +18,11 @@
 
     <properties>
         <java.version>21</java.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <snakeyaml.version>2.2</snakeyaml.version>
         <oracle-free.version>1.19.3</oracle-free.version>
+        <commons-compress.version>1.24.0</commons-compress.version>
     </properties>
 
     <dependencies>
@@ -29,7 +33,20 @@
             <optional>true</optional>
         </dependency>
 
-        <!-- Infrastructure-->
+        <!--    Fix transitive dependencies vulnerabilities   -->
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>${snakeyaml.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>${commons-compress.version}</version>
+        </dependency>
+
+        <!--    Infrastructure    -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-docker-compose</artifactId>
@@ -50,13 +67,13 @@
             <optional>true</optional>
         </dependency>
 
-        <!-- Infrastructure - Web Adapters -->
+        <!--    Infrastructure - Web Adapters    -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
 
-        <!-- Infrastructure - Persistence Adapters -->
+        <!--     Infrastructure - Persistence Adapters     -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
@@ -73,7 +90,7 @@
             <scope>runtime</scope>
         </dependency>
 
-        <!-- Infrastructure - Testing -->
+        <!--     Infrastructure - Testing     -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
@@ -110,6 +127,7 @@
                     <compilerArgs>--enable-preview</compilerArgs>
                 </configuration>
             </plugin>
+
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
@@ -124,6 +142,81 @@
                         </exclude>
                     </excludes>
                 </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>2.41.1</version>
+                <configuration>
+                    <pom>
+                        <includes>
+                            <include>pom.xml</include>
+                        </includes>
+                        <sortPom>
+                            <nrOfIndentSpace>4</nrOfIndentSpace>
+                            <expandEmptyElements>false</expandEmptyElements>
+                        </sortPom>
+                    </pom>
+                    <java>
+                        <includes>
+                            <include>src/main/java/**/*.java</include>
+                            <include>src/test/java/**/*.java</include>
+                        </includes>
+                        <importOrder/>
+                        <removeUnusedImports/>
+                        <toggleOffOn/>
+                        <trimTrailingWhitespace/>
+                        <endWithNewline/>
+                        <indent>
+                            <tabs>true</tabs>
+                            <spacesPerTab>4</spacesPerTab>
+                        </indent>
+                        <palantirJavaFormat/>
+                    </java>
+                    <yaml>
+                        <includes>
+                            <include>**/*.yml</include>
+                            <include>src/**/*.yaml</include>
+                        </includes>
+                        <jackson/>
+                    </yaml>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>format</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <phase>process-sources</phase>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.3.1</version>
+                <executions>
+                    <execution>
+                        <id>install-pre-commit-hook</id>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <outputDirectory>${basedir}/.git/hooks</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${basedir}/scripts</directory>
+                                    <includes>
+                                        <include>pre-commit</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Assign all staged files to a variable
+stagedFiles=$(git diff --staged --name-only)
+
+# Apply the formatting
+echo "Running spotlessApply. Formatting code..."
+./gradlew spotlessApply
+# mvn spotless:apply
+
+# Re-add staged files
+for file in $stagedFiles; do
+  if test -f "$file"; then
+    git add $file
+  fi
+done

--- a/src/main/java/org/github/ehayik/kata/persons/Application.java
+++ b/src/main/java/org/github/ehayik/kata/persons/Application.java
@@ -9,5 +9,4 @@ public class Application {
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
     }
-
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,8 @@
+---
 spring:
   datasource:
-    url: jdbc:oracle:thin:@localhost/FREEPDB1
-    username: PERSONS_DB
-    password: Lider0ne
+    url: "jdbc:oracle:thin:@localhost/FREEPDB1"
+    username: "PERSONS_DB"
+    password: "Lider0ne"
   liquibase:
     enabled: false

--- a/src/test/java/org/github/ehayik/kata/persons/ApplicationTests.java
+++ b/src/test/java/org/github/ehayik/kata/persons/ApplicationTests.java
@@ -1,5 +1,8 @@
 package org.github.ehayik.kata.persons;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
@@ -8,10 +11,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.oracle.OracleContainer;
 import org.testcontainers.utility.DockerImageName;
 
-import java.time.Duration;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 @SpringBootTest
 @Testcontainers
 class ApplicationTests {
@@ -19,7 +18,7 @@ class ApplicationTests {
     @Container
     @ServiceConnection
     static OracleContainer oracle = new OracleContainer(DockerImageName.parse("gvenzl/oracle-free:slim-faststart")
-            .asCompatibleSubstituteFor("gvenzl/oracle-free"))
+                    .asCompatibleSubstituteFor("gvenzl/oracle-free"))
             // increase startup timeout when using docker & colima on Apple M1
             .withStartupTimeout(Duration.ofMinutes(5))
             .withUsername("PERSONS_DB")


### PR DESCRIPTION
The Spotless Maven plugin has been added to ensure consistent formatting across the codebase.
A pre-commit Git hook has been added to automatically format staged files. This will help in maintaining code quality by ensuring that all committed code follows the same formatting standards.
The pom.xml file was also slightly refactored.

closes issue #1 