### PR TITLE
Add JPA entities to map database PERSONS and ADDRESSES tables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
         <snakeyaml.version>2.2</snakeyaml.version>
         <oracle-free.version>1.19.3</oracle-free.version>
         <commons-compress.version>1.24.0</commons-compress.version>
+        <equalsverifier.version>3.15.5</equalsverifier.version>
     </properties>
 
     <dependencies>
@@ -47,6 +48,11 @@
         </dependency>
 
         <!--    Infrastructure    -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-docker-compose</artifactId>
@@ -113,6 +119,13 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>oracle-free</artifactId>
             <version>${oracle-free.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>nl.jqno.equalsverifier</groupId>
+            <artifactId>equalsverifier</artifactId>
+            <version>${equalsverifier.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/org/github/ehayik/kata/persons/application/domain/Gender.java
+++ b/src/main/java/org/github/ehayik/kata/persons/application/domain/Gender.java
@@ -1,0 +1,13 @@
+package org.github.ehayik.kata.persons.application.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Gender {
+    M("male"),
+    F("female");
+
+    private final String label;
+}

--- a/src/main/java/org/github/ehayik/kata/persons/infrastructure/adapter/persistence/AddressEntity.java
+++ b/src/main/java/org/github/ehayik/kata/persons/infrastructure/adapter/persistence/AddressEntity.java
@@ -1,0 +1,79 @@
+package org.github.ehayik.kata.persons.infrastructure.adapter.persistence;
+
+import static jakarta.persistence.GenerationType.SEQUENCE;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.RowId;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Entity
+@Getter
+@Setter
+@ToString
+@RowId("ROWID")
+@Accessors(chain = true)
+@Table(name = "ADDRESSES")
+class AddressEntity {
+
+    @Id
+    @GeneratedValue(strategy = SEQUENCE, generator = "ADDRESSES_id_gen")
+    @SequenceGenerator(name = "ADDRESSES_id_gen", sequenceName = "ADDRESS_SEQ", allocationSize = 1)
+    @Column(name = "ADDRESS_ID", nullable = false)
+    private Integer id;
+
+    @NotBlank
+    @Size(max = 250)
+    @Column(name = "STREET", nullable = false, length = 250)
+    private String street;
+
+    @NotBlank
+    @Size(max = 100)
+    @Column(name = "BUILDING_NUMBER", nullable = false, length = 100)
+    private String buildingNumber;
+
+    @NotBlank
+    @Size(max = 100)
+    @Column(name = "CITY", nullable = false, length = 100)
+    private String city;
+
+    @NotBlank
+    @Size(max = 100)
+    @Column(name = "COUNTRY", nullable = false, length = 100)
+    private String country;
+
+    @NotBlank
+    @Size(max = 20)
+    @Column(name = "ZIP_CODE", nullable = false, length = 20)
+    private String zipCode;
+
+    @NotNull
+    @CreationTimestamp
+    @Column(name = "CREATED_ON", nullable = false, updatable = false)
+    private LocalDateTime createdOn;
+
+    @NotNull
+    @UpdateTimestamp
+    @Column(name = "LAST_UPDATED_ON", nullable = false)
+    private LocalDateTime lastUpdatedOn;
+
+    @Override
+    public final boolean equals(Object obj) {
+        if (this == obj) return true;
+        return (obj instanceof AddressEntity other) && Objects.equals(getId(), other.getId());
+    }
+
+    @Override
+    public final int hashCode() {
+        return getClass().hashCode();
+    }
+}

--- a/src/main/java/org/github/ehayik/kata/persons/infrastructure/adapter/persistence/AddressEntity.java
+++ b/src/main/java/org/github/ehayik/kata/persons/infrastructure/adapter/persistence/AddressEntity.java
@@ -1,16 +1,17 @@
 package org.github.ehayik.kata.persons.infrastructure.adapter.persistence;
 
 import static jakarta.persistence.GenerationType.SEQUENCE;
+import static org.hibernate.annotations.SourceType.DB;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 import java.util.Objects;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import lombok.ToString.Include;
 import lombok.experimental.Accessors;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.RowId;
@@ -56,13 +57,13 @@ class AddressEntity {
     @Column(name = "ZIP_CODE", nullable = false, length = 20)
     private String zipCode;
 
-    @NotNull
-    @CreationTimestamp
+    @Include
+    @CreationTimestamp(source = DB)
     @Column(name = "CREATED_ON", nullable = false, updatable = false)
     private LocalDateTime createdOn;
 
-    @NotNull
-    @UpdateTimestamp
+    @Include
+    @UpdateTimestamp(source = DB)
     @Column(name = "LAST_UPDATED_ON", nullable = false)
     private LocalDateTime lastUpdatedOn;
 

--- a/src/main/java/org/github/ehayik/kata/persons/infrastructure/adapter/persistence/PersonEntity.java
+++ b/src/main/java/org/github/ehayik/kata/persons/infrastructure/adapter/persistence/PersonEntity.java
@@ -1,8 +1,10 @@
 package org.github.ehayik.kata.persons.infrastructure.adapter.persistence;
 
+import static jakarta.persistence.CascadeType.PERSIST;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.SEQUENCE;
 import static org.hibernate.annotations.OnDeleteAction.RESTRICT;
+import static org.hibernate.annotations.SourceType.DB;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
@@ -57,7 +59,6 @@ class PersonEntity {
 
     @Include
     @NotNull
-    @Size(max = 1)
     @Enumerated
     @Column(name = "GENDER", nullable = false)
     private Gender gender;
@@ -73,14 +74,12 @@ class PersonEntity {
     private String email;
 
     @Include
-    @NotNull
-    @CreationTimestamp
+    @CreationTimestamp(source = DB)
     @Column(name = "CREATED_ON", nullable = false, updatable = false)
     private LocalDateTime createdOn;
 
     @Include
-    @NotNull
-    @UpdateTimestamp
+    @UpdateTimestamp(source = DB)
     @Column(name = "LAST_UPDATED_ON", nullable = false)
     private LocalDateTime lastUpdatedOn;
 
@@ -89,7 +88,7 @@ class PersonEntity {
      * @see <a href="https://vladmihalcea.com/jpa-entity-graph">Jpa Entity Graph</a>
      * */
     @NotNull
-    @ManyToOne(fetch = LAZY, optional = false)
+    @ManyToOne(fetch = LAZY, cascade = PERSIST, optional = false)
     @OnDelete(action = RESTRICT)
     @JoinColumn(name = "ADDRESS_ID", nullable = false)
     private AddressEntity address;

--- a/src/main/java/org/github/ehayik/kata/persons/infrastructure/adapter/persistence/PersonEntity.java
+++ b/src/main/java/org/github/ehayik/kata/persons/infrastructure/adapter/persistence/PersonEntity.java
@@ -1,0 +1,107 @@
+package org.github.ehayik.kata.persons.infrastructure.adapter.persistence;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.SEQUENCE;
+import static org.hibernate.annotations.OnDeleteAction.RESTRICT;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.ToString.Include;
+import lombok.experimental.Accessors;
+import org.github.ehayik.kata.persons.application.domain.Gender;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.RowId;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Getter
+@Setter
+@Entity
+@RowId("ROWID")
+@Table(name = "PERSONS")
+@Accessors(chain = true)
+@ToString(onlyExplicitlyIncluded = true)
+class PersonEntity {
+
+    @Id
+    @Include
+    @GeneratedValue(strategy = SEQUENCE, generator = "PERSONS_id_gen")
+    @SequenceGenerator(name = "PERSONS_id_gen", sequenceName = "PERSON_SEQ", allocationSize = 1)
+    @Column(name = "PERSON_ID", nullable = false)
+    private Long id;
+
+    @Include
+    @NotBlank
+    @Size(max = 100)
+    @Column(name = "FIRST_NAME", nullable = false, length = 100)
+    private String firstName;
+
+    @Include
+    @NotBlank
+    @Size(max = 100)
+    @Column(name = "LAST_NAME", nullable = false, length = 100)
+    private String lastName;
+
+    @Include
+    @NotNull
+    @Column(name = "BIRTH_DATE", nullable = false)
+    private LocalDate birthDate;
+
+    @Include
+    @NotNull
+    @Size(max = 1)
+    @Enumerated
+    @Column(name = "GENDER", nullable = false)
+    private Gender gender;
+
+    @Include
+    @Size(max = 20)
+    @Column(name = "PHONE", nullable = false, length = 20)
+    private String phone;
+
+    @Include
+    @Size(max = 50)
+    @Column(name = "EMAIL", nullable = false, length = 50)
+    private String email;
+
+    @Include
+    @NotNull
+    @CreationTimestamp
+    @Column(name = "CREATED_ON", nullable = false, updatable = false)
+    private LocalDateTime createdOn;
+
+    @Include
+    @NotNull
+    @UpdateTimestamp
+    @Column(name = "LAST_UPDATED_ON", nullable = false)
+    private LocalDateTime lastUpdatedOn;
+
+    /**
+     * It's a good practice to set all <code>@ManyToOne</code> associations to use <code>FetchType.LAZY</code> strategy
+     * @see <a href="https://vladmihalcea.com/jpa-entity-graph">Jpa Entity Graph</a>
+     * */
+    @NotNull
+    @ManyToOne(fetch = LAZY, optional = false)
+    @OnDelete(action = RESTRICT)
+    @JoinColumn(name = "ADDRESS_ID", nullable = false)
+    private AddressEntity address;
+
+    @Override
+    public final boolean equals(Object obj) {
+        if (this == obj) return true;
+        return (obj instanceof PersonEntity other) && Objects.equals(getId(), other.getId());
+    }
+
+    @Override
+    public final int hashCode() {
+        return getClass().hashCode();
+    }
+}

--- a/src/test/java/org/github/ehayik/kata/persons/infrastructure/adapter/persistence/AddressEntityTests.java
+++ b/src/test/java/org/github/ehayik/kata/persons/infrastructure/adapter/persistence/AddressEntityTests.java
@@ -1,0 +1,17 @@
+package org.github.ehayik.kata.persons.infrastructure.adapter.persistence;
+
+import static nl.jqno.equalsverifier.Warning.ALL_FIELDS_SHOULD_BE_USED;
+import static nl.jqno.equalsverifier.Warning.STRICT_HASHCODE;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class AddressEntityTests {
+
+    @Test
+    void shouldMeetEqualsAndHashCodeContract() {
+        EqualsVerifier.forClass(AddressEntity.class)
+                .suppress(ALL_FIELDS_SHOULD_BE_USED, STRICT_HASHCODE)
+                .verify();
+    }
+}

--- a/src/test/java/org/github/ehayik/kata/persons/infrastructure/adapter/persistence/PersistenceIT.java
+++ b/src/test/java/org/github/ehayik/kata/persons/infrastructure/adapter/persistence/PersistenceIT.java
@@ -3,20 +3,24 @@ package org.github.ehayik.kata.persons.infrastructure.adapter.persistence;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.github.ehayik.kata.persons.infrastructure.adapter.persistence.PersonEntityFactory.DEFAULT_PERSON_ID;
 import static org.github.ehayik.kata.persons.infrastructure.adapter.persistence.PersonEntityFactory.createDefaultPerson;
+import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace.NONE;
 
 import java.time.Duration;
+import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.oracle.OracleContainer;
 import org.testcontainers.utility.DockerImageName;
 
-@SpringBootTest
+@DataJpaTest
 @Testcontainers
+@AutoConfigureTestDatabase(replace = NONE)
 class PersistenceIT {
 
     @Container
@@ -42,5 +46,7 @@ class PersistenceIT {
 
         // Then
         assertThat(person.getId()).isEqualTo(DEFAULT_PERSON_ID);
+        assertThat(person.getCreatedOn().toLocalDate()).isEqualTo(LocalDate.now());
+        assertThat(person.getLastUpdatedOn().toLocalDate()).isEqualTo(LocalDate.now());
     }
 }

--- a/src/test/java/org/github/ehayik/kata/persons/infrastructure/adapter/persistence/PersistenceIT.java
+++ b/src/test/java/org/github/ehayik/kata/persons/infrastructure/adapter/persistence/PersistenceIT.java
@@ -1,9 +1,13 @@
-package org.github.ehayik.kata.persons;
+package org.github.ehayik.kata.persons.infrastructure.adapter.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.github.ehayik.kata.persons.infrastructure.adapter.persistence.PersonEntityFactory.DEFAULT_PERSON_ID;
+import static org.github.ehayik.kata.persons.infrastructure.adapter.persistence.PersonEntityFactory.createDefaultPerson;
 
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.testcontainers.junit.jupiter.Container;
@@ -13,7 +17,7 @@ import org.testcontainers.utility.DockerImageName;
 
 @SpringBootTest
 @Testcontainers
-class ApplicationTests {
+class PersistenceIT {
 
     @Container
     @ServiceConnection
@@ -24,9 +28,19 @@ class ApplicationTests {
             .withUsername("PERSONS_DB")
             .withPassword("Lider0ne");
 
+    @Autowired
+    private TestEntityManager testEntityManager;
+
     @Test
-    void connectionEstablished() {
-        assertThat(oracle.isCreated()).isTrue();
-        assertThat(oracle.isRunning()).isTrue();
+    void shouldPersistPersonEntity() {
+        // Given
+        var person = createDefaultPerson();
+
+        // When
+        person = testEntityManager.persist(person);
+        testEntityManager.flush();
+
+        // Then
+        assertThat(person.getId()).isEqualTo(DEFAULT_PERSON_ID);
     }
 }

--- a/src/test/java/org/github/ehayik/kata/persons/infrastructure/adapter/persistence/PersonEntityFactory.java
+++ b/src/test/java/org/github/ehayik/kata/persons/infrastructure/adapter/persistence/PersonEntityFactory.java
@@ -1,12 +1,10 @@
 package org.github.ehayik.kata.persons.infrastructure.adapter.persistence;
 
-import lombok.NoArgsConstructor;
-import org.github.ehayik.kata.persons.application.domain.Gender;
-
+import static lombok.AccessLevel.PACKAGE;
 
 import java.time.LocalDate;
-
-import static lombok.AccessLevel.PACKAGE;
+import lombok.NoArgsConstructor;
+import org.github.ehayik.kata.persons.application.domain.Gender;
 
 @NoArgsConstructor(access = PACKAGE)
 class PersonEntityFactory {
@@ -17,6 +15,7 @@ class PersonEntityFactory {
         var address = new AddressEntity()
                 .setStreet("517 Stark Rapid")
                 .setBuildingNumber("74653")
+                .setCountry("Zimbabwe")
                 .setCity("Stephaniaberg")
                 .setZipCode("Zimbabwe");
         return new PersonEntity()

--- a/src/test/java/org/github/ehayik/kata/persons/infrastructure/adapter/persistence/PersonEntityFactory.java
+++ b/src/test/java/org/github/ehayik/kata/persons/infrastructure/adapter/persistence/PersonEntityFactory.java
@@ -1,0 +1,31 @@
+package org.github.ehayik.kata.persons.infrastructure.adapter.persistence;
+
+import lombok.NoArgsConstructor;
+import org.github.ehayik.kata.persons.application.domain.Gender;
+
+
+import java.time.LocalDate;
+
+import static lombok.AccessLevel.PACKAGE;
+
+@NoArgsConstructor(access = PACKAGE)
+class PersonEntityFactory {
+
+    static final int DEFAULT_PERSON_ID = 1;
+
+    static PersonEntity createDefaultPerson() {
+        var address = new AddressEntity()
+                .setStreet("517 Stark Rapid")
+                .setBuildingNumber("74653")
+                .setCity("Stephaniaberg")
+                .setZipCode("Zimbabwe");
+        return new PersonEntity()
+                .setFirstName("Lindsay")
+                .setLastName("Farrell")
+                .setBirthDate(LocalDate.parse("1943-04-09"))
+                .setGender(Gender.M)
+                .setPhone("+2151259822482")
+                .setEmail("beer.eliseo@yahoo.com")
+                .setAddress(address);
+    }
+}

--- a/src/test/java/org/github/ehayik/kata/persons/infrastructure/adapter/persistence/PersonEntityTests.java
+++ b/src/test/java/org/github/ehayik/kata/persons/infrastructure/adapter/persistence/PersonEntityTests.java
@@ -1,0 +1,16 @@
+package org.github.ehayik.kata.persons.infrastructure.adapter.persistence;
+
+import static nl.jqno.equalsverifier.Warning.*;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class PersonEntityTests {
+
+    @Test
+    void shouldMeetEqualsAndHashCodeContract() {
+        EqualsVerifier.forClass(PersonEntity.class)
+                .suppress(ALL_FIELDS_SHOULD_BE_USED, STRICT_HASHCODE)
+                .verify();
+    }
+}


### PR DESCRIPTION
This commit introduces Base Persistence classes for PersonEntity and AddressEntity and respective test cases.
Adds dependency for 'equalsverifier' and 'spring-boot-starter-validation' and creates enums for Gender.
The ApplicationTests has been transformed into PersistenceIT to validate the Persistence layer.

closes #7 