### PR TITLE
Add high-performance tips for Oracle, JPA and Hibernate

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,3 +4,19 @@ spring:
     url: "jdbc:oracle:thin:@localhost/FREEPDB1"
     username: "PERSONS_DB"
     password: "Lider0ne"
+  jpa:
+    open-in-view: false
+    hibernate:
+      ddl-auto: "none"
+    properties:
+      hibernate:
+        query:
+          in_clause_parameter_padding: true
+        criteria:
+          literal_handling_mode: "bind"
+        jdbc:
+          fetch_size: 100
+          batch_size: 100
+          batch_versioned_data: true
+        order_inserts: true
+        order_updates: true


### PR DESCRIPTION
The configuration properties for JPA as well as for Hibernate have been added to the application resources file. This specifies things like fetch size, batch size, and batch versioned data and enables query in-clause parameter padding, among other settings. The settings ensure more efficient database queries and updates, and better handling of literal criteria.

closes #12 